### PR TITLE
Move to Decorator Pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/shaungrady/angular-http-etag/issues"
   },
   "dependencies": {
-    "browserify-shim": "^3.8.8",
+    "object-keys": "^1.0.4",
     "query-string": "^2.3.0"
   },
   "peerDependencies": {

--- a/src/config.js
+++ b/src/config.js
@@ -1,9 +1,12 @@
 'use strict';
 
+var angular    = require('angular');
 module.exports = httpEtagModuleConfig;
 
-httpEtagModuleConfig.$inject = ['$httpProvider'];
+httpEtagModuleConfig.$inject = ['$provide', '$httpProvider'];
 
-function httpEtagModuleConfig ($httpProvider) {
+function httpEtagModuleConfig ($provide, $httpProvider) {
   $httpProvider.interceptors.push('httpEtagInterceptor');
+  // Temporary property for use in run block
+  angular.module('http-etag')._$provide = $provide;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var angular     = require('angular');
+var objectKeys  = require('object-keys');
 var queryString = require('query-string');
 
 var provider    = require('./provider');
@@ -10,6 +11,8 @@ var run         = require('./run');
 
 module.exports = angular
   .module('http-etag', [])
+  
+  .value('objectKeys', objectKeys)
   .value('queryStringify', queryString.stringify)
 
   .provider('httpEtag', provider)

--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,19 @@
 
 var angular     = require('angular');
 var queryString = require('query-string');
+
+var provider    = require('./provider');
 var interceptor = require('./interceptor');
 var config      = require('./config');
+var run         = require('./run');
 
 module.exports = angular
   .module('http-etag', [])
   .value('queryStringify', queryString.stringify)
+
+  .provider('httpEtag', provider)
   .factory('httpEtagInterceptor', interceptor)
   .config(config)
+  .run(run)
+
   .name;

--- a/src/interceptor.js
+++ b/src/interceptor.js
@@ -3,113 +3,22 @@
 var angular = require('angular');
 module.exports = httpEtagInterceptorFactory;
 
-httpEtagInterceptorFactory.$inject = ['$q', '$cacheFactory', 'queryStringify'];
+httpEtagInterceptorFactory.$inject = ['httpEtag'];
 
-function httpEtagInterceptorFactory ($q, $cacheFactory, queryStringify) {
-  var defaultCache = $cacheFactory('httpEtag');
+function httpEtagInterceptorFactory (httpEtag) {
 
-  function buildUrlKey (url, params) {
-    var queryString = queryStringify(params);
-    url += ((url.indexOf('?') == -1) ? '?' : '&') + queryString;
-    return url;
-  }
+  function responseInterceptor (response) {
+    var config   = response.config,
+        cacheKey = config.etagCacheKey;
 
-  function getCacheFactoryData (cacheId, cacheKey) {
-    if (angular.isDefined(cacheId) && angular.isDefined(cacheKey)) {
-      var cache     = $cacheFactory.get(cacheId),
-          cacheData = cache ? cache.get(cacheKey) : undefined;
-      return cacheData;
-    }
-  }
-
-
-  // Request
-  function etagRequestInterceptor (config) {
-    if (!config.etag || !(config.method == 'GET' || config.method == 'JSONP'))
-      return config;
-
-    var etag, key, cacheData;
-
-    switch (typeof config.etag) {
-      // Using user-provided cache
-      case 'object':
-        cacheData = getCacheFactoryData(config.etag.cache.id, config.etag.cache.key);
-        etag      = angular.isObject(cacheData) ? cacheData.$$etag : undefined;
-        break;
-
-      // Using user-provided etag string, fall through to provide ETag caching
-      case 'string':
-        etag = config.etag;
-
-      // Using default cache
-      case 'boolean':
-        key  = buildUrlKey(config.url, config.params);
-        etag = etag || defaultCache.get(key);
-        config.$$etagDefaultCacheKey = key;
-    }
-
-    if (etag)
-      config.headers = angular.extend({}, config.headers, {
-        'If-None-Match': etag
+    if (cacheKey)
+      httpEtag.cachePut(config.etag, cacheKey, {
+        data: response.data,
+        etag: response.headers().etag
       });
-
-    return config;
-  }
-
-
-  // Response
-  function etagResponseInterceptor (response) {
-    if (!response.config.etag)
-      return response;
-
-    var config = response.config,
-        etag   = response.headers().etag,
-        cache, cacheKey, cacheValue;
-
-    switch (typeof config.etag) {
-      case 'object':
-        cache    = $cacheFactory.get(config.etag.cache.id);
-        cacheKey = config.etag.cache.key;
-        if (!cache || !angular.isObject(response.data))
-          return response;
-        response.data.$$etag = etag;
-        cacheValue = response.data;
-        break;
-
-      case 'string':
-      case 'boolean':
-        cache      = defaultCache;
-        cacheKey   = config.$$etagDefaultCacheKey;
-        cacheValue = etag;
-        delete config.$$etagDefaultCacheKey;
-    }
-
-    cache.put(cacheKey, cacheValue);
 
     return response;
   }
 
-
-  // Response Error
-  function etagResponseErrorInterceptor (rejection) {
-    var etagConfig = rejection.config.etag,
-        cacheData;
-
-    if (rejection.status == 304 && etagConfig && etagConfig.cache) {
-
-
-      cacheData = getCacheFactoryData(etagConfig.cache.id, etagConfig.cache.key);
-      if (angular.isDefined(cacheData))
-        rejection.data = cacheData;
-    }
-
-    return $q.reject(rejection);
-  }
-
-
-  return {
-    request:       etagRequestInterceptor,
-    response:      etagResponseInterceptor,
-    responseError: etagResponseErrorInterceptor
-  };
+  return { response: responseInterceptor };
 }

--- a/src/provider.js
+++ b/src/provider.js
@@ -20,27 +20,34 @@ function httpEtagProvider () {
   };
 
 
-  self.$get = ['$cacheFactory', function ($cacheFactory) {
+  self.$get = ['$cacheFactory', 'queryStringify', function ($cacheFactory, queryStringify) {
 
     angular.forEach(caches, function httpEtagCacheBuilder (opts, id) {
       $cacheFactory(id, opts);
     });
 
+    function httpEtagGetCacheKey (url, params) {
+      var queryString = queryStringify(params);
+      url += ((url.indexOf('?') == -1) ? '?' : '&') + queryString;
+      return url;
+    }
+
     // Abstract get/put operations for future support
     // of different caching plugins allowing for web storage.
     function httpEtagGetCacheValue (id, key) {
-      id = id || defaultCacheId;
+      id = id === true ? defaultCacheId : id;
       $cacheFactory.get(id).get(key);
     }
 
-    function httpEtagPutCacheValue (id, key) {
-      id = id || defaultCacheId;
-      $cacheFactory.get(id).put(key);
+    function httpEtagPutCacheValue (id, key, value) {
+      id = id === true ? defaultCacheId : id;
+      $cacheFactory.get(id).put(key, value);
     }
 
     return {
-      cacheGet: httpEtagGetCacheValue,
-      cachePut: httpEtagPutCacheValue
+      getCacheKey: httpEtagGetCacheKey,
+      cacheGet:    httpEtagGetCacheValue,
+      cachePut:    httpEtagPutCacheValue
     };
 
   }];

--- a/src/provider.js
+++ b/src/provider.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var angular    = require('angular');
+module.exports = httpEtagProvider;
+
+function httpEtagProvider () {
+  var self           = this,
+      caches         = {},
+      cacheService   = '$cacheFactory',
+      defaultCacheId = 'httpEtagDefault';
+
+  // Default cache
+  caches[defaultCacheId] = {
+    number: 25
+  };
+
+  self.cache = function httpEtagProviderCache (id, opts) {
+    caches[id] = opts || {};
+    return self;
+  };
+
+
+  self.$get = ['$cacheFactory', function ($cacheFactory) {
+
+    angular.forEach(caches, function httpEtagCacheBuilder (opts, id) {
+      $cacheFactory(id, opts);
+    });
+
+    // Abstract get/put operations for future support
+    // of different caching plugins allowing for web storage.
+    function httpEtagGetCacheValue (id, key) {
+      id = id || defaultCacheId;
+      $cacheFactory.get(id).get(key);
+    }
+
+    function httpEtagPutCacheValue (id, key) {
+      id = id || defaultCacheId;
+      $cacheFactory.get(id).put(key);
+    }
+
+    return {
+      cacheGet: httpEtagGetCacheValue,
+      cachePut: httpEtagPutCacheValue
+    };
+
+  }];
+}

--- a/src/provider.js
+++ b/src/provider.js
@@ -7,7 +7,8 @@ function httpEtagProvider () {
   var self             = this,
       caches           = {},
       cacheServiceName = '$cacheFactory',
-      defaultCacheId   = 'httpEtagDefault';
+      cacheIdPrefix    = 'etag-',
+      defaultCacheId   = cacheIdPrefix + 'default';
 
   // Default cache
   caches[defaultCacheId] = {
@@ -15,7 +16,7 @@ function httpEtagProvider () {
   };
 
   self.cache = function httpEtagProviderCache (id, opts) {
-    caches[id] = opts || {};
+    caches[cacheIdPrefix + id] = opts || {};
     return self;
   };
 
@@ -35,12 +36,12 @@ function httpEtagProvider () {
     // Abstract get/put operations for future support
     // of different caching plugins allowing for web storage.
     function httpEtagGetCacheValue (id, key) {
-      id = id === true ? defaultCacheId : id;
+      id = id === true ? defaultCacheId : cacheIdPrefix + id;
       return cacheService.get(id).get(key);
     }
 
     function httpEtagPutCacheValue (id, key, value) {
-      id = id === true ? defaultCacheId : id;
+      id = id === true ? defaultCacheId : cacheIdPrefix + id;
       cacheService.get(id).put(key, value);
     }
 

--- a/src/provider.js
+++ b/src/provider.js
@@ -4,10 +4,10 @@ var angular    = require('angular');
 module.exports = httpEtagProvider;
 
 function httpEtagProvider () {
-  var self           = this,
-      caches         = {},
-      cacheService   = '$cacheFactory',
-      defaultCacheId = 'httpEtagDefault';
+  var self             = this,
+      caches           = {},
+      cacheServiceName = '$cacheFactory',
+      defaultCacheId   = 'httpEtagDefault';
 
   // Default cache
   caches[defaultCacheId] = {
@@ -20,10 +20,10 @@ function httpEtagProvider () {
   };
 
 
-  self.$get = ['$cacheFactory', 'queryStringify', function ($cacheFactory, queryStringify) {
+  self.$get = [cacheServiceName, 'queryStringify', function (cacheService, queryStringify) {
 
     angular.forEach(caches, function httpEtagCacheBuilder (opts, id) {
-      $cacheFactory(id, opts);
+      cacheService(id, opts);
     });
 
     function httpEtagGetCacheKey (url, params) {
@@ -36,12 +36,12 @@ function httpEtagProvider () {
     // of different caching plugins allowing for web storage.
     function httpEtagGetCacheValue (id, key) {
       id = id === true ? defaultCacheId : id;
-      return $cacheFactory.get(id).get(key);
+      return cacheService.get(id).get(key);
     }
 
     function httpEtagPutCacheValue (id, key, value) {
       id = id === true ? defaultCacheId : id;
-      $cacheFactory.get(id).put(key, value);
+      cacheService.get(id).put(key, value);
     }
 
     return {

--- a/src/provider.js
+++ b/src/provider.js
@@ -36,7 +36,7 @@ function httpEtagProvider () {
     // of different caching plugins allowing for web storage.
     function httpEtagGetCacheValue (id, key) {
       id = id === true ? defaultCacheId : id;
-      $cacheFactory.get(id).get(key);
+      return $cacheFactory.get(id).get(key);
     }
 
     function httpEtagPutCacheValue (id, key, value) {

--- a/src/run.js
+++ b/src/run.js
@@ -3,8 +3,84 @@
 var angular    = require('angular');
 module.exports = httpEtagModuleRun;
 
-httpEtagModuleRun.$inject = ['httpEtag'];
+httpEtagModuleRun.$inject = ['httpEtag', 'objectKeys'];
 
-function httpEtagModuleRun (httpEtag) {
+function httpEtagModuleRun (httpEtag, objectKeys) {
+  var $provide = angular.module('http-etag')._$provide;
+  delete angular.module('http-etag')._$provide;
+
+  $provide.decorator('$http', function ($delegate) {
+    var $http = $delegate,
+        http, httpMethod;
+
+    // TODO: DRY up http, httpMethod
+
+    http = function httpEtagHttpWrapper (config) {
+      var isEtagReq = config.etag && (config.method == 'GET' || config.method == 'JSONP'),
+          cacheKey, cacheValue, etag, promise;
+
+      if (isEtagReq) {
+        cacheKey   = httpEtag.getCacheKey(config.url, config.params);
+        cacheValue = httpEtag.cacheGet(config.etag, cacheKey);
+        etag       = cacheValue ? cacheValue.etag : undefined;
+
+        if (etag)
+          config.headers = angular.extend({}, config.headers, {
+            'If-None-Match': etag
+          });
+      }
+
+      promise = $http.apply($http, arguments);
+
+      if (isEtagReq)
+        promise.cache = function (fn) {
+          if (cacheValue)
+            fn(cacheValue.data, cacheKey);
+          return promise;
+        };
+
+      return promise;
+    };
+
+
+    httpMethod = function httpEtagHttpMethodWrapper (url, config) {
+      config = config || {};
+
+      var method    = this,
+          isEtagReq = config.etag && (method == 'GET' || method == 'JSONP'),
+          cacheKey, cacheValue, etag, promise;
+
+      if (isEtagReq) {
+        cacheKey   = httpEtag.getCacheKey(url, config.params);
+        cacheValue = httpEtag.cacheGet(config.etag, cacheKey);
+        etag       = cacheValue ? cacheValue.etag : undefined;
+
+        if (etag)
+          config.headers = angular.extend({}, config.headers, {
+            'If-None-Match': etag
+          });
+      }
+
+      promise = $http[method].apply($http, arguments);
+
+      if (isEtagReq)
+        promise.cache = function (fn) {
+          if (cacheValue)
+            fn(cacheValue.data, cacheKey);
+          return promise;
+        };
+
+      return promise;
+    };
+
+
+    // Wrap all the shortcut methods
+    angular.forEach(objectKeys($http), function (key) {
+      if (angular.isFunction($http[key]))
+        http[key] = angular.bind(key, httpMethod);
+    });
+
+    return http;
+  });
 
 }

--- a/src/run.js
+++ b/src/run.js
@@ -20,6 +20,7 @@ function httpEtagModuleRun (httpEtag, objectKeys) {
           cacheKey, cacheValue, etag, promise;
 
       if (isEtagReq) {
+        config.etagCacheKey =
         cacheKey   = httpEtag.getCacheKey(config.url, config.params);
         cacheValue = httpEtag.cacheGet(config.etag, cacheKey);
         etag       = cacheValue ? cacheValue.etag : undefined;
@@ -47,10 +48,11 @@ function httpEtagModuleRun (httpEtag, objectKeys) {
       config = config || {};
 
       var method    = this,
-          isEtagReq = config.etag && (method == 'GET' || method == 'JSONP'),
+          isEtagReq = config.etag && (method == 'get' || method == 'jsonp'),
           cacheKey, cacheValue, etag, promise;
 
       if (isEtagReq) {
+        config.etagCacheKey =
         cacheKey   = httpEtag.getCacheKey(url, config.params);
         cacheValue = httpEtag.cacheGet(config.etag, cacheKey);
         etag       = cacheValue ? cacheValue.etag : undefined;

--- a/src/run.js
+++ b/src/run.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var angular    = require('angular');
+module.exports = httpEtagModuleRun;
+
+httpEtagModuleRun.$inject = ['httpEtag'];
+
+function httpEtagModuleRun (httpEtag) {
+
+}

--- a/test/etag.js
+++ b/test/etag.js
@@ -104,7 +104,8 @@ describe('angular-http-etag', function () {
     $http.get('/1.json', { etag: 'test' })
       .cache(function (data) {
         userData = data;
-      });
+      })
+      .error(onError);
     $httpBackend.flush();
 
     $http.get('/1.json', { etag: true })
@@ -113,6 +114,7 @@ describe('angular-http-etag', function () {
 
     userData.should.deep.equal(serverData);
     onSuccess.should.have.been.called.once;
+    onError.should.have.been.called.once;
   });
 
 

--- a/test/etag.js
+++ b/test/etag.js
@@ -13,10 +13,16 @@ require('angular-mocks/ngMock');
 
 
 describe('angular-http-etag', function () {
-  beforeEach(angular.mock.module(require('../')));
-
-  var $http, $httpBackend, $cacheFactory, serverData,
+  var $http, $httpBackend, $cacheFactory, testModule, serverData,
       ifEtagIs, ifEtagIsNot, onCache, onSuccess, onError;
+
+  testModule = angular.module('test', ['http-etag']).config(['httpEtagProvider', function (httpEtagProvider) {
+    httpEtagProvider.cache('test');
+  }]);
+
+  beforeEach(angular.mock.module(require('../')));
+  beforeEach(angular.mock.module('test'));
+
 
   beforeEach(angular.mock.inject(function ($injector) {
     $http         = $injector.get('$http');
@@ -54,37 +60,59 @@ describe('angular-http-etag', function () {
   }));
 
 
-
   it('should cache ETags', function () {
     $http.get('/1.json', { etag: true })
+      .cache(onCache)
       .success(onSuccess);
     $httpBackend.flush();
 
     $http.get('/1.json', { etag: true })
+      .cache(onCache)
       .error(onError);
     $httpBackend.flush();
 
-    onSuccess.should.have.been.called();
-    onError.should.have.been.called();
+    onCache.should.have.been.called.once;
+    onSuccess.should.have.been.called.once;
+    onError.should.have.been.called.once;
   });
 
 
   it('should cache data', function () {
     var userData;
 
+    $http({ method:'GET', url: '/1.json', etag: true })
+      .cache(onCache);
+    $httpBackend.flush();
+
+    $http({ method:'GET', url: '/1.json', etag: true })
+      .cache(function (data) {
+        userData = data;
+      });
+    $httpBackend.flush();
+
+    onCache.should.not.have.been.called();
+    userData.should.deep.equal(serverData);
+  });
+
+
+  it('should cache data on specified cache ID', function () {
+    var userData;
+
+    $http.get('/1.json', { etag: 'test' });
+    $httpBackend.flush();
+
+    $http.get('/1.json', { etag: 'test' })
+      .cache(function (data) {
+        userData = data;
+      });
+    $httpBackend.flush();
+
     $http.get('/1.json', { etag: true })
       .success(onSuccess);
     $httpBackend.flush();
 
-    $http.get('/1.json', { etag: true })
-      .cache(function (data) {
-        userData = data;
-      })
-      .error(onError);
-    $httpBackend.flush();
-
     userData.should.deep.equal(serverData);
-    onError.should.have.been.called();
+    onSuccess.should.have.been.called.once;
   });
 
 
@@ -92,11 +120,11 @@ describe('angular-http-etag', function () {
     $http.get('/1.json').success(onSuccess);
     $httpBackend.flush();
 
-    $http.get('/1.json').error(onError);
+    $http({ method: 'GET', url: '/1.json'}).error(onError);
     $httpBackend.flush();
 
-    onSuccess.should.have.been.called();
-    onError.should.not.have.been.called();
+    onSuccess.should.have.been.called.once;
+    onError.should.not.have.been.called.once;
   });
 
 
@@ -109,8 +137,8 @@ describe('angular-http-etag', function () {
       .error(onError);
     $httpBackend.flush();
 
-    onSuccess.should.have.been.called();
-    onError.should.have.been.called();
+    onSuccess.should.have.been.once;
+    onError.should.have.been.once;
   });
 
 


### PR DESCRIPTION
This will allow for attaching a new `cache` method on the promise returned by $http that will call the provided function with cached data, if it exists. This will allow for a cleaner, more intuitive implementation.

An `httpEtagProvider` will also allow for configuring caches for use by the module and allow for the use of 3rd-party cache services in the future.