### PR TITLE
Fix cached ETag-wipe bug

### DIFF
--- a/src/httpDecorator.js
+++ b/src/httpDecorator.js
@@ -32,9 +32,9 @@ function httpEtagHttpDecorator ($delegate, httpEtag) {
         if (!itemCache) throw new Error('No defined ETag caches match specified cache ID')
 
         var cacheInfo = itemCache.info()
-        var cachedData = itemCache.get()
-        var cachedEtag = cachedData && cachedData.etagHeader
-        var cachedResponse = cachedEtag && cachedData.responseData
+        var rawCacheData = itemCache.$get()
+        var cachedEtag = rawCacheData && rawCacheData.etagHeader
+        var cachedResponse = cachedEtag && rawCacheData.responseData
 
         // Allow easy access to cache in interceptor
         httpConfig.$$_itemCache = itemCache
@@ -50,7 +50,7 @@ function httpEtagHttpDecorator ($delegate, httpEtag) {
     httpPromise = $http.apply($http, arguments)
 
     httpPromise.cached = function (callback) {
-      if (isCachable && cachedData && cacheInfo.cacheResponseData) callback(cachedResponse, 'cached', undefined, httpConfig, itemCache)
+      if (isCachable && rawCacheData && cacheInfo.cacheResponseData) callback(cachedResponse, 'cached', undefined, httpConfig, itemCache)
       return httpPromise
     }
 

--- a/src/httpInterceptor.js
+++ b/src/httpInterceptor.js
@@ -15,7 +15,7 @@ function httpEtagInterceptorFactory () {
       if (etag) {
         cacheData.etagHeader = etag
         if (cacheResponseData) cacheData.responseData = response.data
-        itemCache.set(cacheData)
+        itemCache.$set(cacheData)
       }
 
       delete response.config.$$_itemCache

--- a/test/httpDecorator.js
+++ b/test/httpDecorator.js
@@ -116,11 +116,30 @@ describe('HTTP Decorator', function () {
 
     $http.get('/1.json', { etagCache: true })
       .cached(cachedSpy)
+      .success(successSpy)
       .error(errorSpy)
     $httpBackend.flush()
 
     cachedSpy.should.have.been.called.once
+    successSpy.should.have.been.called.once
     errorSpy.should.have.been.called.once
+  })
+
+  it('should not let cached ETag get wiped by modifying cache data', function () {
+    $http.get('/1.json', { etagCache: true })
+    $httpBackend.flush()
+
+    $http.get('/1.json', { etagCache: true })
+      .cached(function (data, status, headers, config, itemCache) {
+        itemCache.unset()
+      })
+    $httpBackend.flush()
+
+    $http.get('/1.json', { etagCache: true })
+      .cached(cachedSpy)
+    $httpBackend.flush()
+
+    cachedSpy.should.have.been.called.once
   })
 
   it('should use a different itemKey for requests with params', function () {


### PR DESCRIPTION
Fix an issue where, if you modify a cache item after the ETag has been
cached, the ETag will be wiped and won’t be sent to the server on the
next request.