### PR TITLE
Add namespacing to web storage caches

### DIFF
--- a/src/cacheServiceAdapters.js
+++ b/src/cacheServiceAdapters.js
@@ -41,7 +41,7 @@ function cacheAdaptersConfig (httpEtagProvider) {
       },
       methods: {
         createCache: angular.noop,
-        getCache: function (undef, cacheId) {
+        getCache: function (localStorage, cacheId) {
           return cacheId
         },
         setItem: function (cacheId, itemKey, value) {
@@ -75,7 +75,7 @@ function cacheAdaptersConfig (httpEtagProvider) {
       },
       methods: {
         createCache: angular.noop,
-        getCache: function (undef, cacheId) {
+        getCache: function (sessionStorage, cacheId) {
           return cacheId
         },
         setItem: function (cacheId, itemKey, value) {

--- a/src/cacheServiceAdapters.js
+++ b/src/cacheServiceAdapters.js
@@ -45,19 +45,19 @@ function cacheAdaptersConfig (httpEtagProvider) {
           return cacheId
         },
         setItem: function (cacheId, itemKey, value) {
-          itemKey = cacheId + '/' + itemKey
+          itemKey = cacheId + ':' + itemKey
           localStorage.setItem(itemKey, JSON.stringify(value))
         },
         getItem: function (cacheId, itemKey) {
-          itemKey = cacheId + '/' + itemKey
+          itemKey = cacheId + ':' + itemKey
           return JSON.parse(localStorage.getItem(itemKey))
         },
         removeItem: function (cacheId, itemKey) {
-          itemKey = cacheId + '/' + itemKey
+          itemKey = cacheId + ':' + itemKey
           localStorage.removeItem(itemKey)
         },
         removeAllItems: function (cacheId, itemKey) {
-          var keyPrefix = cacheId + '/'
+          var keyPrefix = cacheId + ':'
           var keyPrefixLen = keyPrefix.length
 
           angular.forEach(localStorage, function (value, key) {
@@ -79,19 +79,19 @@ function cacheAdaptersConfig (httpEtagProvider) {
           return cacheId
         },
         setItem: function (cacheId, itemKey, value) {
-          itemKey = cacheId + '/' + itemKey
+          itemKey = cacheId + ':' + itemKey
           sessionStorage.setItem(itemKey, JSON.stringify(value))
         },
         getItem: function (cacheId, itemKey) {
-          itemKey = cacheId + '/' + itemKey
+          itemKey = cacheId + ':' + itemKey
           return JSON.parse(sessionStorage.getItem(itemKey))
         },
         removeItem: function (cacheId, itemKey) {
-          itemKey = cacheId + '/' + itemKey
+          itemKey = cacheId + ':' + itemKey
           sessionStorage.removeItem(itemKey)
         },
         removeAllItems: function (cacheId, itemKey) {
-          var keyPrefix = cacheId + '/'
+          var keyPrefix = cacheId + ':'
           var keyPrefixLen = keyPrefix.length
 
           angular.forEach(sessionStorage, function (value, key) {

--- a/src/cacheServiceAdapters.js
+++ b/src/cacheServiceAdapters.js
@@ -41,21 +41,29 @@ function cacheAdaptersConfig (httpEtagProvider) {
       },
       methods: {
         createCache: angular.noop,
-        getCache: function () {
-          return localStorage
+        getCache: function (undef, cacheId) {
+          return cacheId
         },
-        setItem: function (localStorage, itemKey, value) {
+        setItem: function (cacheId, itemKey, value) {
+          itemKey = cacheId + '/' + itemKey
           localStorage.setItem(itemKey, JSON.stringify(value))
         },
-        getItem: function (localStorage, itemKey) {
+        getItem: function (cacheId, itemKey) {
+          itemKey = cacheId + '/' + itemKey
           return JSON.parse(localStorage.getItem(itemKey))
         },
-        removeItem: function (localStorage, itemKey) {
+        removeItem: function (cacheId, itemKey) {
+          itemKey = cacheId + '/' + itemKey
           localStorage.removeItem(itemKey)
         },
-        removeAllItems: function (localStorage, itemKey) {
+        removeAllItems: function (cacheId, itemKey) {
+          var keyPrefix = cacheId + '/'
+          var keyPrefixLen = keyPrefix.length
+
           angular.forEach(localStorage, function (value, key) {
-            localStorage.removeItem(key)
+            if (key.substr(0, keyPrefixLen) === keyPrefix) {
+              localStorage.removeItem(key)
+            }
           })
         }
       }
@@ -67,21 +75,29 @@ function cacheAdaptersConfig (httpEtagProvider) {
       },
       methods: {
         createCache: angular.noop,
-        getCache: function () {
-          return sessionStorage
+        getCache: function (undef, cacheId) {
+          return cacheId
         },
-        setItem: function (sessionStorage, itemKey, value) {
+        setItem: function (cacheId, itemKey, value) {
+          itemKey = cacheId + '/' + itemKey
           sessionStorage.setItem(itemKey, JSON.stringify(value))
         },
-        getItem: function (sessionStorage, itemKey) {
+        getItem: function (cacheId, itemKey) {
+          itemKey = cacheId + '/' + itemKey
           return JSON.parse(sessionStorage.getItem(itemKey))
         },
-        removeItem: function (sessionStorage, itemKey) {
+        removeItem: function (cacheId, itemKey) {
+          itemKey = cacheId + '/' + itemKey
           sessionStorage.removeItem(itemKey)
         },
-        removeAllItems: function (sessionStorage, itemKey) {
+        removeAllItems: function (cacheId, itemKey) {
+          var keyPrefix = cacheId + '/'
+          var keyPrefixLen = keyPrefix.length
+
           angular.forEach(sessionStorage, function (value, key) {
-            sessionStorage.removeItem(key)
+            if (key.substr(0, keyPrefixLen) === keyPrefix) {
+              sessionStorage.removeItem(key)
+            }
           })
         }
       }

--- a/test/service.js
+++ b/test/service.js
@@ -37,10 +37,19 @@ describe('Service', function () {
           .defineCache('$cacheFactoryTestCache', {
             cacheService: '$cacheFactory'
           })
+          .defineCache('$cacheFactoryTestCacheTwo', {
+            cacheService: '$cacheFactory'
+          })
           .defineCache('localStorageTestCache', {
             cacheService: 'localStorage'
           })
+          .defineCache('localStorageTestCacheTwo', {
+            cacheService: 'localStorage'
+          })
           .defineCache('sessionStorageTestCache', {
+            cacheService: 'sessionStorage'
+          })
+          .defineCache('sessionStorageTestCacheTwo', {
             cacheService: 'sessionStorage'
           })
 
@@ -190,6 +199,21 @@ describe('Service', function () {
           cache.removeAllItems()
           should.not.exist(cache.getItem('test1'))
           should.not.exist(cache.getItem('test2'))
+        })
+      })
+    })
+
+    describe('`removeAllItems` should not remove data from other caches', function () {
+      cacheIds.forEach(function (id) {
+        it('(using ' + id.replace('TestCache', '') + ')', function () {
+          var cache = httpEtag.getCache(id)
+          var otherCache = httpEtag.getCache(id + 'Two')
+
+          cache.setItem('hello', testValue)
+          otherCache.setItem('hello', testValue)
+
+          cache.removeAllItems()
+          should.exist(otherCache.getItem('hello'))
         })
       })
     })


### PR DESCRIPTION
Item keys for `sessionStorage` and `localStorage` are now prefixed with
the cache ID to prevent key collisions with other caches of the same
kind.