### PR TITLE
Catch QuotaExceededError in localStorage/sessionStorage.setItem

### DIFF
--- a/src/cacheServiceAdapters.js
+++ b/src/cacheServiceAdapters.js
@@ -47,9 +47,7 @@ function cacheAdaptersConfig (httpEtagProvider) {
             itemKey = cacheId + ':' + itemKey
             localStorage.setItem(itemKey, JSON.stringify(value))
           } catch (e) {
-            if (e.code !== DOMException.QUOTA_EXCEEDED_ERR) {
-              throw e
-            }
+
           }
         },
         getItem: function getItem (cacheId, itemKey) {
@@ -86,9 +84,7 @@ function cacheAdaptersConfig (httpEtagProvider) {
             itemKey = cacheId + ':' + itemKey
             sessionStorage.setItem(itemKey, JSON.stringify(value))
           } catch (e) {
-            if (e.code !== DOMException.QUOTA_EXCEEDED_ERR) {
-              throw e
-            }
+
           }
         },
         getItem: function getItem (cacheId, itemKey) {

--- a/src/cacheServiceAdapters.js
+++ b/src/cacheServiceAdapters.js
@@ -43,8 +43,14 @@ function cacheAdaptersConfig (httpEtagProvider) {
           return cacheId
         },
         setItem: function setItem (cacheId, itemKey, value) {
-          itemKey = cacheId + ':' + itemKey
-          localStorage.setItem(itemKey, JSON.stringify(value))
+          try {
+            itemKey = cacheId + ':' + itemKey
+            localStorage.setItem(itemKey, JSON.stringify(value))
+          } catch (e) {
+            if (e.code !== DOMException.QUOTA_EXCEEDED_ERR) {
+              throw e
+            }
+          }
         },
         getItem: function getItem (cacheId, itemKey) {
           itemKey = cacheId + ':' + itemKey
@@ -76,8 +82,14 @@ function cacheAdaptersConfig (httpEtagProvider) {
           return cacheId
         },
         setItem: function setItem (cacheId, itemKey, value) {
-          itemKey = cacheId + ':' + itemKey
-          sessionStorage.setItem(itemKey, JSON.stringify(value))
+          try {
+            itemKey = cacheId + ':' + itemKey
+            sessionStorage.setItem(itemKey, JSON.stringify(value))
+          } catch (e) {
+            if (e.code !== DOMException.QUOTA_EXCEEDED_ERR) {
+              throw e
+            }
+          }
         },
         getItem: function getItem (cacheId, itemKey) {
           itemKey = cacheId + ':' + itemKey

--- a/test/service.js
+++ b/test/service.js
@@ -14,6 +14,7 @@ var cacheIds = [
 ]
 var testValue
 var testRawValue
+var testBigValue
 
 describe('Service', function () {
   beforeEach(function () {
@@ -23,6 +24,7 @@ describe('Service', function () {
       etagHeader: '101',
       other: testValue
     }
+    testBigValue = 'x'.repeat(12*1024*1024/2)
 
     angular
       .module('test', ['http-etag'])
@@ -242,6 +244,22 @@ describe('Service', function () {
           itemCache.get.should.be.a('function')
           itemCache.set.should.be.a('function')
           itemCache.remove.should.be.a('function')
+        })
+      })
+    })
+
+    describe('`setItem` should not throw exception on very large items', function () {
+      cacheIds.forEach(function (id) {
+        it('(using ' + id.replace('TestCache', '') + ')', function () {
+          var exception
+          var cache = httpEtag.getCache(id)
+          try {
+              cache.setItem('test', testBigValue)
+          } catch (e) {
+              exception = e;
+          }
+          should.not.exist(exception)
+          should.not.exist(cache.getItem('test'))
         })
       })
     })

--- a/test/service.js
+++ b/test/service.js
@@ -254,9 +254,9 @@ describe('Service', function () {
           var exception
           var cache = httpEtag.getCache(id)
           try {
-              cache.setItem('test', testBigValue)
+            cache.setItem('test', testBigValue)
           } catch (e) {
-              exception = e;
+            exception = e;
           }
           should.not.exist(exception)
           should.not.exist(cache.getItem('test'))


### PR DESCRIPTION
Calling localStorage/sessionStorage.setItem with a large value can cause a DOMException.QuotaExceededError to be thrown.  This change catches this error silently since the value is too large to be cached.