### PR TITLE
Allow caching of headers

### DIFF
--- a/docs/http_decorator.md
+++ b/docs/http_decorator.md
@@ -22,7 +22,7 @@ var promise = $http
 
   .cached(function (data, status, headers, config, itemCache) {
     // status === 'cached'
-    // headers === undefined
+    // headers === undefined (default) or header === function() (read docs below)
     self.fullName = data._fullName
   })
 
@@ -50,7 +50,9 @@ Instead of being asynchronous like `success` and `error` are, `cached` is synchr
 If the request being made has previously cached data associated with it, `cached`
 will be called immediately and the cached data response data will be returned
 in the `data` argument. Since it's not a true server response, the `status` argument
-is set to `'cached'` instead of an HTTP Status Code, and `headers` is `undefined`.
+is set to `'cached'` instead of an HTTP Status Code.
+By default `headers` is `undefined`, this behavious can be changed by using the `cacheResponseHeaders`
+option in the default cache config, setting it to true will return the headers as they appear in the normal response (as a function).
 The `config` argument will return the `$http` config as normal.
 
 Lastly, an `itemCache` is passed in as the 5th argument allowing for easily

--- a/docs/service_provider.md
+++ b/docs/service_provider.md
@@ -7,13 +7,13 @@ cache services.
 
 ``` javascript
 angular
-  .module('myModule', ['angular-http-etag'])
+  .module('myModule', ['http-etag'])
   .config(function(httpEtagProvider) {
 
     httpEtagProvider
       .setDefaultCacheConfig({
         // Default cacheService is `$cacheFactory`
-        cacheOptions: { number: 10 }          
+        cacheOptions: { number: 10 }
       })
       .defineCache('lruCache', {
         deepCopy: true
@@ -78,6 +78,7 @@ httpEtagProvider
 | `cacheOptions` | `object` | Options passed to the cache service when instantiating the cache. |
 | `deepCopy` | `boolean` | Create a deep copy of the data when setting and getting cache data. |
 | `cacheResponseData` | `boolean` | Whether or not the response data should be cached. ETag header will be cached regardless.
+| `cacheResponseHeaders` | `boolean` | Wether or not the response headers should be cached |
 
 Default configuration:
 
@@ -88,7 +89,8 @@ Default configuration:
     number: 25
   },
   deepCopy: false,
-  cacheResponseData: true
+  cacheResponseData: true,
+  cacheResponseHeaders: false
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 [![npm version](https://badge.fury.io/js/angular-http-etag.svg)](http://badge.fury.io/js/angular-http-etag)
 [![Build Status](https://travis-ci.org/shaungrady/angular-http-etag.svg?branch=master)](https://travis-ci.org/shaungrady/angular-http-etag)
 [![Test Coverage](https://codeclimate.com/github/shaungrady/angular-http-etag/badges/coverage.svg)](https://codeclimate.com/github/shaungrady/angular-http-etag/coverage)
-[![Code Climate](https://codeclimate.com/github/shaungrady/angular-http-etag/badges/gpa.svg)](https://codeclimate.com/github/shaungrady/angular-http-etag)  
+[![Code Climate](https://codeclimate.com/github/shaungrady/angular-http-etag/badges/gpa.svg)](https://codeclimate.com/github/shaungrady/angular-http-etag)
 [![Dependency Status](https://david-dm.org/shaungrady/angular-http-etag.svg)](https://david-dm.org/shaungrady/angular-http-etag)
 [![devDependency Status](https://david-dm.org/shaungrady/angular-http-etag/dev-status.svg)](https://david-dm.org/shaungrady/angular-http-etag#info=devDependencies)
 [![JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
@@ -16,6 +16,7 @@ Easy ETag-based caching for `$http` service requests! Increase responsiveness, d
 
 * Caches ETag headers and sends them back to the server in the `If-None-Match` header.
 * Caches response data with flexible cache configuration.
+* Supports caching of headers when configured
 * Support for `$cacheFactory`, `sessionStorage`, and `localStorage` caches out-of-the-box.
 * Easily [adaptable][Cache Service Adapters] for other third-party cache services.
 
@@ -99,7 +100,7 @@ Include `'http-etag'` in your module's dependencies.
 ``` javascript
 // The node module exports the string 'http-etag'...
 angular.module('myApp', [
-  require('angular-http-etag')
+  require('http-etag')
 ])
 ```
 

--- a/src/httpDecorator.js
+++ b/src/httpDecorator.js
@@ -30,6 +30,7 @@ function httpEtagHttpDecorator ($delegate, httpEtag) {
         var rawCacheData = itemCache.$get()
         var cachedEtag = rawCacheData && rawCacheData.etagHeader
         var cachedResponse = cachedEtag && rawCacheData.responseData
+        var cachedHeaders = cachedEtag && rawCacheData.responseHeaders
 
         // Allow easy access to cache in interceptor
         httpConfig.$$_itemCache = itemCache
@@ -51,7 +52,7 @@ function httpEtagHttpDecorator ($delegate, httpEtag) {
 
       httpPromise.cached = function httpEtagPromiseCached (callback) {
         if (isCachable && rawCacheData && cacheInfo.cacheResponseData) {
-          callback(cachedResponse, 'cached', undefined, httpConfig, itemCache)
+          callback(cachedResponse, 'cached', cachedHeaders, httpConfig, itemCache)
         }
         return httpPromise
       }

--- a/src/httpInterceptor.js
+++ b/src/httpInterceptor.js
@@ -6,14 +6,14 @@ function httpEtagInterceptorFactory () {
 
     if (itemCache) {
       var cacheInfo = itemCache.info()
-	  var cacheResponseData = cacheInfo.cacheResponseData
+      var cacheResponseData = cacheInfo.cacheResponseData
       var cacheResponseHeaders = cacheInfo.cacheResponseHeaders
       var etag = response.headers().etag
       var cacheData = {}
 
       if (etag) {
         cacheData.etagHeader = etag
-		if (cacheResponseData) cacheData.responseData = response.data
+        if (cacheResponseData) cacheData.responseData = response.data
         //TODO: Allow user to speficy which headers to cache?
         if(cacheResponseHeaders) cacheData.responseHeaders = response.headers
         itemCache.$set(cacheData)

--- a/src/httpInterceptor.js
+++ b/src/httpInterceptor.js
@@ -6,13 +6,16 @@ function httpEtagInterceptorFactory () {
 
     if (itemCache) {
       var cacheInfo = itemCache.info()
-      var cacheResponseData = cacheInfo.cacheResponseData
+	  var cacheResponseData = cacheInfo.cacheResponseData
+      var cacheResponseHeaders = cacheInfo.cacheResponseHeaders
       var etag = response.headers().etag
       var cacheData = {}
 
       if (etag) {
         cacheData.etagHeader = etag
-        if (cacheResponseData) cacheData.responseData = response.data
+		if (cacheResponseData) cacheData.responseData = response.data
+        //TODO: Allow user to speficy which headers to cache?
+        if(cacheResponseHeaders) cacheData.responseHeaders = response.headers
         itemCache.$set(cacheData)
       }
 

--- a/src/service.js
+++ b/src/service.js
@@ -30,6 +30,7 @@ function httpEtagProvider () {
   var defaultEtagCacheConfig = {
     deepCopy: false,
     cacheResponseData: true,
+    cacheResponseHeaders: false,
     cacheService: '$cacheFactory',
     cacheOptions: {
       number: 25


### PR DESCRIPTION
This functionality allows the module to cache response headers as well, when configured.
Since it is disabled by default, no breaking change is introduced.

When cached, the headers returned are exactly the same as the ones that are returned from a normal request. So headers are retrievable in the `cached` method the same way as in the `success` and `then` method.

Perhaps later on this could be extended so users can select per request if they want to cache the headers, or which headers to cache.

It's a different PR than what we discussed yesterday, but needed this functionality myself as well :D
Also, I noticed after settings `setDefaultCacheConfig  = true` I needed to call `defineCache('httpEtagCache')` before those default options where used without defining another cache. Is this intentional?