### PR TITLE
Added ifCached function

### DIFF
--- a/src/httpDecorator.js
+++ b/src/httpDecorator.js
@@ -56,6 +56,10 @@ function httpEtagHttpDecorator ($delegate, httpEtag) {
           }
           return httpPromise
         }
+      } else {
+        httpPromise.cached = function () {
+          throw new Error('The method `cached` on the promise returned from `$http` has been disabled.')
+        }
       }
 
       httpPromise.ifCached = function httpEtagPromiseIfCached (successCallback, errorCallback, progressBackCallback) {

--- a/src/httpDecorator.js
+++ b/src/httpDecorator.js
@@ -50,7 +50,7 @@ function httpEtagHttpDecorator ($delegate, httpEtag) {
       var success = httpPromise.success
 
       if (useLegacyPromiseExtensions) {
-        httpPromise.cached = function httpEtagPromiseCached(callback) {
+        httpPromise.cached = function httpEtagPromiseCached (callback) {
           if (isCachable && rawCacheData && cacheInfo.cacheResponseData) {
             callback(cachedResponse, 'cached', undefined, httpConfig, itemCache)
           }
@@ -58,14 +58,14 @@ function httpEtagHttpDecorator ($delegate, httpEtag) {
         }
       }
 
-      httpPromise.ifCached = function httpEtagPromiseIfCached(successCallback, errorCallback, progressBackCallback) {
+      httpPromise.ifCached = function httpEtagPromiseIfCached (successCallback, errorCallback, progressBackCallback) {
         if (isCachable && rawCacheData && cacheInfo.cacheResponseData) {
           successCallback({
             data: cachedResponse,
             status: 'cached',
             headers: undefined,
             config: httpConfig
-          }, itemCache);
+          }, itemCache)
         }
       }
 

--- a/src/httpDecorator.js
+++ b/src/httpDecorator.js
@@ -71,6 +71,7 @@ function httpEtagHttpDecorator ($delegate, httpEtag) {
             config: httpConfig
           }, itemCache)
         }
+        return httpPromise
       }
 
       httpPromise.then = function httpEtagThenWrapper (successCallback, errorCallback, progressBackCallback) {

--- a/src/httpDecorator.js
+++ b/src/httpDecorator.js
@@ -49,11 +49,24 @@ function httpEtagHttpDecorator ($delegate, httpEtag) {
       var then = httpPromise.then
       var success = httpPromise.success
 
-      httpPromise.cached = function httpEtagPromiseCached (callback) {
-        if (isCachable && rawCacheData && cacheInfo.cacheResponseData) {
-          callback(cachedResponse, 'cached', undefined, httpConfig, itemCache)
+      if (useLegacyPromiseExtensions) {
+        httpPromise.cached = function httpEtagPromiseCached(callback) {
+          if (isCachable && rawCacheData && cacheInfo.cacheResponseData) {
+            callback(cachedResponse, 'cached', undefined, httpConfig, itemCache)
+          }
+          return httpPromise
         }
-        return httpPromise
+      }
+
+      httpPromise.ifCached = function httpEtagPromiseIfCached(successCallback, errorCallback, progressBackCallback) {
+        if (isCachable && rawCacheData && cacheInfo.cacheResponseData) {
+          successCallback({
+            data: cachedResponse,
+            status: 'cached',
+            headers: undefined,
+            config: httpConfig
+          }, itemCache);
+        }
       }
 
       httpPromise.then = function httpEtagThenWrapper (successCallback, errorCallback, progressBackCallback) {

--- a/test/httpDecorator.js
+++ b/test/httpDecorator.js
@@ -295,6 +295,18 @@ describe('HTTP Decorator', function () {
     $http(httpConfig).success.should.throw(Error)
   })
 
+  it('should not wrap `cached` when `useLegacyPromiseExtensions` is false', function () {
+    $httpProvider.useLegacyPromiseExtensions(false)
+
+    var httpConfig = {
+      method: 'GET',
+      url: '/1.json',
+      etagCache: true
+    }
+
+    $http(httpConfig).cached.should.throw(Error)
+  })
+
   it('should use the default cacheId with `{ etagCache: true }`', function () {
     $http.get('/1.json', { etagCache: true })
     $httpBackend.flush()

--- a/test/httpDecorator.js
+++ b/test/httpDecorator.js
@@ -14,6 +14,7 @@ var $http
 var $httpBackend
 
 var cachedSpy
+var ifCachedSpy
 var successSpy
 var errorSpy
 
@@ -58,6 +59,7 @@ describe('HTTP Decorator', function () {
       $httpBackend = $injector.get('$httpBackend')
 
       cachedSpy = spy('cached', angular.noop)
+      ifCachedSpy = spy('ifCached', angular.noop)
       successSpy = spy('success', angular.noop)
       errorSpy = spy('error', angular.noop)
 
@@ -196,6 +198,33 @@ describe('HTTP Decorator', function () {
         config.method.should.equal(httpConfig.method)
         config.url.should.equal(httpConfig.url)
         config.etagCache.should.equal(httpConfig.etagCache)
+        var cacheInfo = itemCache.info()
+        cacheInfo.id.should.equal('httpEtagCache')
+      })
+      .error(errorSpy)
+    $httpBackend.flush()
+  })
+
+  it('should call `ifCached` callback with proper arguments', function () {
+    var httpConfig = {
+      method: 'GET',
+      url: '/1.json',
+      etagCache: true
+    }
+
+    $http(httpConfig)
+      .ifCached(ifCachedSpy)
+      .success(successSpy)
+    $httpBackend.flush()
+
+    $http(httpConfig)
+      .ifCached(function (response, itemCache) {
+        response.data.should.deep.equal(mockResponseData)
+        response.status.should.equal('cached')
+        should.not.exist(response.headers)
+        response.config.method.should.equal(httpConfig.method)
+        response.config.url.should.equal(httpConfig.url)
+        response.config.etagCache.should.equal(httpConfig.etagCache)
         var cacheInfo = itemCache.info()
         cacheInfo.id.should.equal('httpEtagCache')
       })


### PR DESCRIPTION
As discussed, the `.ifCached` method uses the same callback method as the `.then` method.

Right now nothing happens when `useLegacyPromiseExtensions` is set to false, the application will just throw a general error saying the `.cached` function does not exist for the method (when it is used). I noticed in the angular code itself they throw the legacy errors like this:
```
var $httpMinErr = minErr('$http');
var $httpMinErrLegacyFn = function(method) {
  return function() {
    throw $httpMinErr('legacy', 'The method `{0}` on the promise returned from `$http` has been disabled.', method);
  };
};
```
(https://github.com/angular/angular.js/blob/v1.5.x/src/ng/http.js#L12)

Which they invoke using:
```
promise.success = $httpMinErrLegacyFn('success');
```
(https://github.com/angular/angular.js/blob/v1.5.x/src/ng/http.js#L1006)

I will try and see if it's possible to import this method, but it doesn't seem like it. If not, do you think it's worth making it the same kind of error, or should a generic thrown error be sufficient?