### PR TITLE
Fix CommonJS module export

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = {
     path: './lib',
     filename: 'index.js',
     library: 'http-etag',
-    libraryTarget: 'commonjs'
+    libraryTarget: 'commonjs2'
   },
   plugins: [
     new webpack.BannerPlugin({ banner, raw: true, entryOnly: true })


### PR DESCRIPTION
`exports["http-etag"] =` => `module.exports =` as it was in `v2.0.14`.